### PR TITLE
fix: load select data only on scroll

### DIFF
--- a/packages/kaspersky-hexa-ui/src/select/Select.tsx
+++ b/packages/kaspersky-hexa-ui/src/select/Select.tsx
@@ -7,7 +7,6 @@ import { Divider } from '@src/divider'
 import { Loader } from '@src/loader'
 import { Tag, TagProps } from '@src/tag'
 import cn from 'classnames'
-import once from 'lodash/once'
 import RcSelect, { BaseSelectRef, OptGroup as RcOptGroup, Option as RcOption } from 'rc-select'
 import React, {
   forwardRef,
@@ -55,10 +54,12 @@ export const Select = forwardRef<HTMLElement, SelectProps>((props, ref) => {
 
   const [selectOffsetWidth, setSelectOffsetWidth] = useState<number>()
 
-  // once - to prevent next trigger after user scrolls out and in
-  const handleLoadMore = useMemo(() => once(() => {
-    onLoadMore?.()
-  }), [onLoadMore])
+  const onLoadMoreRef = useRef(onLoadMore)
+  onLoadMoreRef.current = onLoadMore
+
+  const handleLoadMore = useCallback(() => {
+    onLoadMoreRef.current?.()
+  }, [])
   const isMultiSelect = props.mode === 'multiple' || props.mode === 'tags'
 
   function renderOption (option: OptionType) {

--- a/packages/kaspersky-hexa-ui/src/select/__tests__/Select.loadMore.test.tsx
+++ b/packages/kaspersky-hexa-ui/src/select/__tests__/Select.loadMore.test.tsx
@@ -1,0 +1,295 @@
+import { ConfigProvider } from '@design-system/context'
+import { act, render, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import { LoadingTrigger } from '../helpers'
+import { Select } from '../Select'
+import { SelectProps } from '../types'
+
+const OriginalIntersectionObserver = global.IntersectionObserver
+
+function makeEntry (isIntersecting: boolean): IntersectionObserverEntry {
+  const target = document.createElement('div')
+  return {
+    boundingClientRect: target.getBoundingClientRect(),
+    intersectionRatio: isIntersecting ? 1 : 0,
+    intersectionRect: {} as DOMRectReadOnly,
+    isIntersecting,
+    rootBounds: null,
+    target,
+    time: 0
+  }
+}
+
+/**
+ * jsdom has no layout; we invoke the observer callback explicitly.
+ * Uses the latest registered callback — mirrors the active observer instance.
+ */
+function setupIntersectionObserverMock (): {
+  fire: (isIntersecting: boolean) => void
+  instances: IntersectionObserverCallback[]
+} {
+  const instances: IntersectionObserverCallback[] = []
+
+  global.IntersectionObserver = jest.fn((cb: IntersectionObserverCallback) => {
+    instances.push(cb)
+    return {
+      disconnect: jest.fn(),
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      takeRecords: jest.fn(() => [])
+    } as unknown as IntersectionObserver
+  }) as unknown as typeof IntersectionObserver
+
+  const fire = (isIntersecting: boolean): void => {
+    act(() => {
+      const cb = instances.length ? instances[instances.length - 1] : undefined
+      if (!cb) {
+        return
+      }
+      cb([makeEntry(isIntersecting)], {} as IntersectionObserver)
+    })
+  }
+
+  return { instances, fire }
+}
+
+function ScrollBox ({ children }: { children: React.ReactNode }): JSX.Element {
+  return (
+    <div
+      style={{ height: 80, overflowY: 'auto', width: 200 }}
+    >
+      {children}
+    </div>
+  )
+}
+
+async function flushAnimationFrame (): Promise<void> {
+  await act(async () => {
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+  })
+}
+
+/** RTL is configured with testIdAttribute=kl-id; Load-more Loader only sets data-testid. */
+function queryLoadMoreSpinner (): HTMLElement | null {
+  return document.querySelector('[data-testid="select-option-loading-more"]')
+}
+
+describe('LoadingTrigger', () => {
+  afterEach(() => {
+    global.IntersectionObserver = OriginalIntersectionObserver
+  })
+
+  test('does not call onLoad until intersection callback reports visible', () => {
+    const onLoad = jest.fn()
+    setupIntersectionObserverMock()
+
+    render(
+      <ConfigProvider>
+        <ScrollBox>
+          <LoadingTrigger onLoad={onLoad} />
+        </ScrollBox>
+      </ConfigProvider>
+    )
+
+    expect(onLoad).not.toHaveBeenCalled()
+  })
+
+  test('calls onLoad once on transition to intersecting', () => {
+    const onLoad = jest.fn()
+    const { fire } = setupIntersectionObserverMock()
+
+    render(
+      <ConfigProvider>
+        <ScrollBox>
+          <LoadingTrigger onLoad={onLoad} />
+        </ScrollBox>
+      </ConfigProvider>
+    )
+
+    fire(true)
+    expect(onLoad).toHaveBeenCalledTimes(1)
+
+    fire(true)
+    expect(onLoad).toHaveBeenCalledTimes(1)
+  })
+
+  test('fires again after leaving intersecting viewport and re-entering (rising edge)', () => {
+    const onLoad = jest.fn()
+    const { fire } = setupIntersectionObserverMock()
+
+    render(
+      <ConfigProvider>
+        <ScrollBox>
+          <LoadingTrigger onLoad={onLoad} />
+        </ScrollBox>
+      </ConfigProvider>
+    )
+
+    fire(true)
+    expect(onLoad).toHaveBeenCalledTimes(1)
+
+    fire(false)
+    fire(true)
+    expect(onLoad).toHaveBeenCalledTimes(2)
+  })
+
+  test('uses latest onLoad after re-render without extra invocations until intersection repeats', () => {
+    const first = jest.fn()
+    const second = jest.fn()
+    const { fire } = setupIntersectionObserverMock()
+
+    const { rerender } = render(
+      <ConfigProvider>
+        <ScrollBox>
+          <LoadingTrigger onLoad={first} />
+        </ScrollBox>
+      </ConfigProvider>
+    )
+
+    fire(true)
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).not.toHaveBeenCalled()
+
+    rerender(
+      <ConfigProvider>
+        <ScrollBox>
+          <LoadingTrigger onLoad={second} />
+        </ScrollBox>
+      </ConfigProvider>
+    )
+
+    expect(second).not.toHaveBeenCalled()
+
+    fire(false)
+    fire(true)
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(first).toHaveBeenCalledTimes(1)
+  })
+
+  test('defer connecting observer until animation frame when no scroll ancestor yet', async () => {
+    const onLoad = jest.fn()
+    const instances: IntersectionObserverCallback[] = []
+
+    global.IntersectionObserver = jest.fn((cb: IntersectionObserverCallback) => {
+      instances.push(cb)
+      return {
+        disconnect: jest.fn(),
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        takeRecords: jest.fn(() => [])
+      } as unknown as IntersectionObserver
+    }) as unknown as typeof IntersectionObserver
+
+    render(
+      <ConfigProvider>
+        {/* no overflow:auto between trigger and viewport — waits rAF before IO */}
+        <div style={{ height: 40 }}>
+          <LoadingTrigger onLoad={onLoad} />
+        </div>
+      </ConfigProvider>
+    )
+
+    expect(onLoad).not.toHaveBeenCalled()
+    expect(instances.length).toBe(0)
+
+    await flushAnimationFrame()
+
+    expect(instances.length).toBeGreaterThanOrEqual(1)
+    expect(onLoad).not.toHaveBeenCalled()
+
+    act(() => {
+      const cb = instances.length ? instances[instances.length - 1] : undefined
+      cb?.([makeEntry(true)], {} as IntersectionObserver)
+    })
+    expect(onLoad).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('Select hasMore', () => {
+  const manyOptions = Array.from({ length: 30 }, (_, i) => ({
+    label: `Option ${i}`,
+    value: String(i)
+  }))
+
+  const loadMoreDefaults: Partial<SelectProps> = {
+    klId: 'load-more-select',
+    testId: 'load-more-select',
+    open: true,
+    /** rc-select warns if themed `onSearch` is passed without showSearch/tags/combobox */
+    showSearch: true,
+    mode: undefined,
+    defaultValue: undefined,
+    options: manyOptions,
+    hasMore: true
+  }
+
+  afterEach(() => {
+    global.IntersectionObserver = OriginalIntersectionObserver
+  })
+
+  async function renderOpenSelectWithPagination (onLoadMore: jest.Mock): Promise<{ fire: (v: boolean) => void }> {
+    const { fire } = setupIntersectionObserverMock()
+    render(
+      <ConfigProvider>
+        <Select {...loadMoreDefaults} onLoadMore={onLoadMore}/>
+      </ConfigProvider>
+    )
+    await waitFor(() => {
+      expect(queryLoadMoreSpinner()).not.toBeNull()
+    })
+    return { fire }
+  }
+
+  test('does not invoke onLoadMore until loading-more row intersects scroll root', async () => {
+    const onLoadMore = jest.fn()
+    setupIntersectionObserverMock()
+
+    render(
+      <ConfigProvider>
+        <Select {...loadMoreDefaults} onLoadMore={onLoadMore}/>
+      </ConfigProvider>
+    )
+
+    await waitFor(() => {
+      expect(queryLoadMoreSpinner()).not.toBeNull()
+    })
+    expect(onLoadMore).not.toHaveBeenCalled()
+  })
+
+  test('calls onLoadMore once when sentinel enters visible area', async () => {
+    const onLoadMore = jest.fn()
+    const { fire } = await renderOpenSelectWithPagination(onLoadMore)
+
+    expect(onLoadMore).not.toHaveBeenCalled()
+    fire(true)
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+
+    fire(true)
+    expect(onLoadMore).toHaveBeenCalledTimes(1)
+  })
+
+  test('changing onLoadMore reference does not call without intersection (mount / rerender)', async () => {
+    const spy = jest.fn()
+    setupIntersectionObserverMock()
+
+    const { rerender } = render(
+      <ConfigProvider>
+        <Select {...loadMoreDefaults} onLoadMore={() => { spy('first') }}/>
+      </ConfigProvider>
+    )
+
+    await waitFor(() => {
+      expect(queryLoadMoreSpinner()).not.toBeNull()
+    })
+    expect(spy).not.toHaveBeenCalled()
+
+    rerender(
+      <ConfigProvider>
+        <Select {...loadMoreDefaults} onLoadMore={() => { spy('second') }}/>
+      </ConfigProvider>
+    )
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/kaspersky-hexa-ui/src/select/helpers.tsx
+++ b/packages/kaspersky-hexa-ui/src/select/helpers.tsx
@@ -4,7 +4,7 @@ import { Loader } from '@src/loader'
 import { Text } from '@src/typography'
 import { Empty } from 'antd'
 import cn from 'classnames'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 import { v1 as uuidV1 } from 'uuid'
@@ -84,6 +84,23 @@ export const findScrollableParent = (node: ParentNode | Element | null): Element
   return null
 }
 
+const findVerticalScrollableParent = (node: ParentNode | Element | null): Element | null => {
+  while (node) {
+    if (node instanceof Element) {
+      const style = window.getComputedStyle(node)
+      const { overflowY, overflow } = style
+      if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+        return node
+      }
+      if (overflow === 'auto' || overflow === 'scroll') {
+        return node
+      }
+    }
+    node = (node as Node).parentNode
+  }
+  return null
+}
+
 export const EmptyData = (): JSX.Element => {
   const { t } = useTranslation()
   return (
@@ -124,11 +141,77 @@ interface LoadingTriggerProps {
 }
 
 export function LoadingTrigger ({ onLoad }: LoadingTriggerProps): JSX.Element {
-  useEffect(() => {
-    onLoad()
-  }, [onLoad])
+  const targetRef = useRef<HTMLDivElement>(null)
+  const onLoadRef = useRef(onLoad)
+  onLoadRef.current = onLoad
 
-  return <Loader centered testId="select-option-loading-more" />
+  useEffect(() => {
+    const el = targetRef.current
+
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      return undefined
+    }
+
+    let observer: IntersectionObserver | undefined
+    let wasIntersecting = false
+    let cancelled = false
+    let retryFrameId = 0
+
+    const resolveScrollRoot = (): Element | null =>
+      findVerticalScrollableParent(el) ??
+      findScrollableParent(el)
+
+    const connect = (scrollRoot: Element | null): void => {
+      observer?.disconnect()
+
+      observer = new IntersectionObserver(
+        ([entry]) => {
+          if (cancelled) {
+            return
+          }
+          const isIntersecting = Boolean(entry?.isIntersecting)
+          if (isIntersecting && !wasIntersecting) {
+            onLoadRef.current()
+          }
+          wasIntersecting = isIntersecting
+        },
+        {
+          ...(scrollRoot ? { root: scrollRoot } : {}),
+          rootMargin: '0px',
+          threshold: 0
+        }
+      )
+
+      observer.observe(el)
+    }
+
+    const scrollRootNow = resolveScrollRoot()
+
+    if (scrollRootNow) {
+      connect(scrollRootNow)
+    } else {
+      retryFrameId = requestAnimationFrame(() => {
+        if (cancelled) {
+          return
+        }
+        connect(resolveScrollRoot())
+      })
+    }
+
+    return () => {
+      cancelled = true
+      observer?.disconnect()
+      if (retryFrameId) {
+        cancelAnimationFrame(retryFrameId)
+      }
+    }
+  }, [])
+
+  return (
+    <div ref={targetRef} style={{ width: '100%' }}>
+      <Loader centered testId="select-option-loading-more" />
+    </div>
+  )
 }
 
 interface LoadingErrorContentProps {


### PR DESCRIPTION
Demo: with problem on remote Storybook and fixed version on local Storybook.

<img width="1007" height="546" alt="video" src="https://github.com/user-attachments/assets/a2ee5d4d-4591-4a19-b0c2-373c23a790d1" />
